### PR TITLE
Shellcheck and environment edge case handling

### DIFF
--- a/manuel
+++ b/manuel
@@ -81,7 +81,7 @@ function load_plugin {
 
 function list {
   tasks=($(declare -F))
-  for t in ${tasks[@]}
+  for t in "${tasks[@]}"
   do
     local task_name=$(printf "%s" "$t" | awk '{ print $3 }')
     if ! [[ "$task_name" =~ ^_(.*) ]]; then
@@ -125,7 +125,7 @@ function _manuel_main {
 
   if [[ -f manuelfile ]]; then
     source manuelfile
-    eval $@
+    eval "$@"
     exit 0
   else
     echo -e "No manuelfile found, exiting"
@@ -137,4 +137,4 @@ function _manuel_main {
 
 
 # execute main function
-_manuel_main $@
+_manuel_main "$@"

--- a/manuel
+++ b/manuel
@@ -83,11 +83,9 @@ function list {
   tasks=($(declare -F))
   for t in ${tasks[@]}
   do
-    if !( [[ $t == "declare" ]] || \
-          [[ $t == "-f" ]] || \
-          [[ "$t" =~ ^_(.*) ]]
-      ); then
-      echo $t
+    local task_name=$(printf "%s" "$t" | awk '{ print $3 }')
+    if ! [[ "$task_name" =~ ^_(.*) ]]; then
+      echo "$task_name"
     fi
   done
 }

--- a/manuel
+++ b/manuel
@@ -69,7 +69,7 @@ function load_plugin {
   fi
 
   plugin_file=$(
-    find "$MANUEL_PLUGIN_DIR" -type f -name "$plugin_name.manuel" | head -1
+    find -L "$MANUEL_PLUGIN_DIR" -type f -name "$plugin_name.manuel" | head -1
   )
 
   if [[ -z $plugin_file ]]; then

--- a/manuel
+++ b/manuel
@@ -97,7 +97,7 @@ function init {
     echo ">> manuelfile already exists, nothing to do"
     exit 0
   else
-    echo ">> Creating new manuelfile in `pwd`"
+    echo ">> Creating new manuelfile in $(pwd)"
     echo '#! /usr/bin/env bash
 
 # run this task with: $ manuel hello

--- a/manuel
+++ b/manuel
@@ -21,9 +21,9 @@ IFS="$(printf '\n\t')"
 # -- #
 MANUEL_VERSION="0.1.2"
 MANUEL_DIR=$(
-  [[ ! -z $MANUEL_DIR ]] && echo $MANUEL_DIR || echo $HOME/.manuel.d
+  [[ ! -z "$MANUEL_DIR" ]] && echo "$MANUEL_DIR" || echo "$HOME/.manuel.d"
 )
-MANUEL_PLUGIN_DIR=$MANUEL_DIR/plugins
+MANUEL_PLUGIN_DIR="$MANUEL_DIR/plugins"
 
 
 # -- # -- # -- # -- # -- # -- # -- #
@@ -48,7 +48,7 @@ EOF
 function _bootstrap {
   if [[ ! -d $MANUEL_PLUGIN_DIR ]]; then
     echo ">> Initializing plugin directory $plugin_dir"
-    mkdir -p $MANUEL_PLUGIN_DIR
+    mkdir -p "$MANUEL_PLUGIN_DIR"
     if [[ $? != "0" ]]; then
       echo ">> Could not create plugin directory $plugin_dir, exiting"
       exit 1
@@ -69,13 +69,13 @@ function load_plugin {
   fi
 
   plugin_file=$(
-    find $MANUEL_PLUGIN_DIR -type f -name "$plugin_name.manuel" | head -1
+    find "$MANUEL_PLUGIN_DIR" -type f -name "$plugin_name.manuel" | head -1
   )
 
   if [[ -z $plugin_file ]]; then
     echo ">> Warning: plugin $plugin_name not found in $MANUEL_PLUGIN_DIR"
   else
-    source $plugin_file
+    source "$plugin_file"
   fi
 }
 

--- a/manuel
+++ b/manuel
@@ -9,6 +9,12 @@
 
 # Usage: manuel [task]
 
+# -- # -- # -- # -- # -- # -- # -- #
+# Setup
+# -- #
+
+# Set IFS to just newline and tab.
+IFS="$(printf '\n\t')"
 
 # -- # -- # -- # -- # -- # -- # -- #
 # Globals


### PR DESCRIPTION
This is a multi-part pull request that mostly includes fixes to help avoid edge cases with different environments. The main things covered in these commits:
- Setting `$IFS` to newline and tab, which helps ensure that arrays don't behave in unexpected ways. This changed also required tweaking the task loading function, since the array no longer splits on spaces.
- Revisions based on ShellCheck recommendations.
- The use of the `-L` option in `find` when loading plugins so symlinks are followed.

The scope of this pull request is slightly broader than I'd normally like, but most of these changes are dependent on each other.

I also added a "Setup" section. I debated about adding this since it currently only contains the `$IFS` setting which is technically a global variable, but I was/still am thinking about this section being used for things like `set -o pipefail` or similar options.

Anyway, feedback welcome. I'm submitting this now since it should be able to be merged without breaking anything.
