### PR TITLE
Correct handling of arguments with spaces in manuel

### DIFF
--- a/manuel
+++ b/manuel
@@ -133,7 +133,7 @@ function _manuel_main {
 
   if [[ -f manuelfile ]]; then
     source manuelfile
-    eval "$@"
+    "$@"
     exit 0
   else
     echo -e "No manuelfile found, exiting"


### PR DESCRIPTION
Don't use eval to launch the commands since this can result in errors
due to spaces not being handled properly.

Example:
```
manuel cli add user -c 1 -u julien --password toto --name "Julien Enselme"
```
will result in `error: unrecognized arguments: Enselme` because Julien
and Enselme are passed as separate arguments.